### PR TITLE
Fix #3 export Stack as default

### DIFF
--- a/stack.d.ts
+++ b/stack.d.ts
@@ -1,4 +1,4 @@
-export class Stack<TData> {
+export default class Stack<TData> {
     public count(): number;
     public isEmpty(): boolean;
     public push(value: TData): void;

--- a/stack.ts
+++ b/stack.ts
@@ -1,4 +1,4 @@
-export class Stack <TData> {
+export default class Stack <TData> {
 
     private _topNode: Node<TData> = undefined;
     private _count: number = 0;

--- a/test/count.test.ts
+++ b/test/count.test.ts
@@ -1,5 +1,5 @@
 import { Expect, Test } from "alsatian";
-import { Stack } from "../stack";
+import Stack from "../stack";
 
 export class CountTestFixture {
 

--- a/test/is-empty.test.ts
+++ b/test/is-empty.test.ts
@@ -1,5 +1,5 @@
 import { Expect, Test } from "alsatian";
-import { Stack } from "../stack";
+import Stack from "../stack";
 
 export class IsEmptyTestFixture {
 

--- a/test/peek.test.ts
+++ b/test/peek.test.ts
@@ -1,5 +1,5 @@
 import { Expect, Test } from "alsatian";
-import { Stack } from "../stack";
+import Stack from "../stack";
 
 export class PeekTestFixture {
 

--- a/test/push-pop.test.ts
+++ b/test/push-pop.test.ts
@@ -1,5 +1,5 @@
 import { Expect, TestCase } from "alsatian";
-import { Stack } from "../stack";
+import Stack from "../stack";
 
 export class PushPopTestFixture {
 


### PR DESCRIPTION
So the issue here is the way you export the module

To export as a class in a module use `export class`
Import via TypeScript `import { Class } from "class"` 
Import via JavaScript (CommonJS) `var Class = require("class").Class` 

To export the class **as** the module use `export default class`
Import via TypeScript `import Class from "class"` 
Import via JavaScript (CommonJS) `var Class = require("class")` 

Note that the TypeScript import is the same as ES6 :)
